### PR TITLE
Skip person if UniqueIdentification is an empty string

### DIFF
--- a/src/Person/PersonsToAccounts.php
+++ b/src/Person/PersonsToAccounts.php
@@ -53,6 +53,12 @@ class PersonsToAccounts
 
     private function getUserID(Person $person): ?int
     {
+
+        $uniqueId = $person->getUniqueIdentification();
+        if ($uniqueId === "") {
+            return null;
+         }
+
         switch (true) {
             case ($person instanceof UserIdPerson):
                 return (int) $person->getUniqueIdentification();


### PR DESCRIPTION
- Added logic to skip processing a person when UniqueIdentification is an empty string.
- Ensures that persons with blank lines (i.e., empty UniqueIdentification) are not processed.